### PR TITLE
adding a git ignore file so our rproj files dont get all messed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+*.Rproj
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+/*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+.Rproj.user
+
+# images
+*.png
+*.jpg
+*.jpeg


### PR DESCRIPTION
Totally want to contribute in the next couple of weeks. Was thing of adding some data to make examples easier to follow in the help docs. I think copy paste examples are one of the criteria for CRAN. Anyway contributing will be a lot easier if we dont have rproj docs that overlap so I added it to the .gitognore file.

peace!